### PR TITLE
add :imagesdir: so images display correctly

### DIFF
--- a/chapters/chapter-incentives.adoc
+++ b/chapters/chapter-incentives.adoc
@@ -1,3 +1,4 @@
+:imagesdir: images
 
 == Incentives
 


### PR DESCRIPTION
I've copied images to mastering-cardano/chapters/images from mastering-cardano/images as I was unable to get images to properly display in the .adoc preview when trying to link from mastering-cardano/images

It seems to work better when the images directory shares the parent directory with the document