### PR TITLE
fix images

### DIFF
--- a/chapters/chapter-cryptography.adoc
+++ b/chapters/chapter-cryptography.adoc
@@ -1,3 +1,5 @@
+:imagesdir: images
+
 [[chap-crypto]]
 == Cryptography
 


### PR DESCRIPTION
add :imagesdir: to specify image directory chapters/images

After copying images from mastering-cardano/images to mastering-cardano/chapters/images this seems to work (sharing a parent directory)