### PR TITLE
fix: artifact version

### DIFF
--- a/.github/workflows/build-epub.yml
+++ b/.github/workflows/build-epub.yml
@@ -3,7 +3,7 @@ name: Build EPUB (TNG)
 on:
   push:
     branches:
-      - main
+      - "**"
 
 jobs:
   build-epub:
@@ -29,6 +29,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Load version from file
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_ENV
+
       - name: Build EPUB
         run: ./build-epub.sh
 
@@ -36,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Book-EPUB-TNG
-          path: dist/mastering-cardano-v1.0.0.epub
+          path: dist/mastering-cardano-${{ env.VERSION}}.epub

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -3,7 +3,7 @@ name: Build PDF
 on:
   push:
     branches:
-      - main
+      - "**"
 
 jobs:
   build-pdf:
@@ -21,8 +21,11 @@ jobs:
       - name: Build PDF
         run: ./build-pdf.sh
 
+      - name: Load version from file
+        run: echo "VERSION=$(cat VERSION)" >> $GITHUB_ENV
+
       - name: Upload PDF Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Book-PDF
-          path: dist/mastering-cardano-v1.0.0.pdf
+          path: dist/mastering-cardano-${{ env.VERSION }}.pdf


### PR DESCRIPTION
Currently, artifacts are not being uploaded due to a version mismatch:

<img width="850" height="63" alt="image" src="https://github.com/user-attachments/assets/91948419-7475-473a-86e8-e77d00bd7bb9" />

This PR fixes the version issue in the GitHub workflow.
Additionally, it enables building both EPUB and PDF on all branches to allow validation of changes within PRs and simplify the review process.